### PR TITLE
Meta description for pages and posts

### DIFF
--- a/content/_includes/base.blade.php
+++ b/content/_includes/base.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="{{$siteDescription}}">
+    <meta name="description" content="@yield('pageDescription', $siteDescription)">
 
     <title>{{$siteName}} @yield('pageTitle')</title>
 

--- a/content/_includes/blog_post_base.blade.php
+++ b/content/_includes/blog_post_base.blade.php
@@ -1,5 +1,7 @@
 @extends('_includes.base')
 
+@section('pageDescription')@yield('post::brief')@endsection
+
 @section('body')
 
     <div class="wrapper m-t-30">


### PR DESCRIPTION
This way you can set meta description per page if wanted and all posts have it already set.

If you are on `/about` page you can set

```
@section('pageDescription', 'This is my about page.')
```

And it will show in meta description for that page. If you leave it out it will show the default `$siteDescription`
